### PR TITLE
Commit Grouping

### DIFF
--- a/src/main/python/github_control/user_account.py
+++ b/src/main/python/github_control/user_account.py
@@ -33,6 +33,7 @@ class UserAccount(object):
         """
         # TODO: refresh Oauth token
         # TODO: handle deleting tokens when a user logs out or just different behavior for passing in a new username and password
+        self.__token = None
         if token_file_path:
             norm_path = os.path.normpath(token_file_path)
             if os.path.exists(norm_path) is False:

--- a/src/main/python/gui/__init__.py
+++ b/src/main/python/gui/__init__.py
@@ -1,0 +1,1 @@
+# present to make python recognize gui as a package

--- a/src/main/python/gui/commit_grouper.py
+++ b/src/main/python/gui/commit_grouper.py
@@ -1,0 +1,20 @@
+from datetime import date
+import time
+import git
+
+# Returns a dictionary where keys are timestamps, and values are lists of
+# commits that fall within those timestamps ordered from earliest time to
+# latest time. Uses the commits in the input list to create this dictionary.
+def group_commits_by_time(commits):
+    result = {}
+    for commit in commits:
+        commit_date = date.fromtimestamp(commit.committed_date)
+        if commit_date not in result:
+            result[commit_date] = []
+        result[commit_date].append(commit)
+    # Sort all the commits from earliest time to latest time within each key
+    for key in result:
+        sorted_commits = sorted(result[key], key=lambda x : x.committed_date)
+        result[key] = sorted_commits
+    return result
+

--- a/src/main/python/gui/commit_grouper.py
+++ b/src/main/python/gui/commit_grouper.py
@@ -18,3 +18,26 @@ def group_commits_by_time(commits):
         result[key] = sorted_commits
     return result
 
+def __get_commit_hunks(commit, hunk_delimiter="\n"):
+    message = commit.message
+    if ":" in message:
+        # remove the filename from the commit message.
+        message = message[message.find(":") + 2:]
+    return message.split(hunk_delimiter)
+
+def group_commits_by_hunk(commits):
+    result = {}
+    hunk_to_commits = {}
+    for commit in commits:
+        hunks = __get_commit_hunks(commit)
+        for hunk in hunks:
+            if hunk not in hunk_to_commits:
+                hunk_to_commits[hunk] = []
+            hunk_to_commits[hunk].append(commit)
+    for hunk in hunk_to_commits:
+        commits = hunk_to_commits[hunk]
+        commits_by_time = group_commits_by_time(commits)
+        if hunk not in result:
+            result[hunk] = []
+        result[hunk] = commits_by_time
+    return result


### PR DESCRIPTION
Create a commit grouping algorithm that works based on time. Commits are grouped into buckets based on the day they occured in.
Create a commit grouping algorithm that works based on hunk headers, and then based on time.