### PR TITLE
[FIX] Authenticated Repository Clone

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,4 +2,4 @@
 *.swp
 *.vscode
 src/token.txt
-local_control_script.py
+local_control_script*

--- a/src/main/python/github_control/user_account.py
+++ b/src/main/python/github_control/user_account.py
@@ -210,7 +210,7 @@ class UserAccount(object):
             local_repo: Repo the push operation is being performed on.
             remote_name: name of remote associated with Repo local_repo.
         
-        Returns a string in the form https://user_login:token@remote_repo_url.git for the
+        Returns a string in the form https://token@remote_repo_url.git for the
         remote_name specified as a remote of local_repo using the GitUp access token and
         the current user's id.
         """

--- a/src/main/python/github_control/user_account.py
+++ b/src/main/python/github_control/user_account.py
@@ -222,6 +222,20 @@ class UserAccount(object):
         url = "https://{}@{}".format(self.__token, url[1])
         return url
     
+    def create_clone_url(self, repo_url: str):
+        """
+        Arguments:
+           repo_url: the clone url of the repo to clone in the form https://remote_repo_url.git
+        
+        Takes in a repo_url of the above form. Returns a repo url in the form 
+        https://user_token@remote_repo_url.git to perform a authenticated clone of the remote repo.
+        """
+        # right half of remote
+        url = repo_url.split("https://")
+        # splice the url correctly
+        url = "https://{}@{}".format(self.__token, url[1])
+        return url
+
     def push_to_remote(self, local_repo):
         """
         Argument:

--- a/src/main/python/local_control/project_manager.py
+++ b/src/main/python/local_control/project_manager.py
@@ -105,13 +105,27 @@ class ProjectManager(object):
         
         # join norm path with repo_name for new directory
         norm_path = os.path.join(norm_path, repo_name)
-        cloned_repo = git.Repo.clone_from(found_repo[1], norm_path, branch='master')
+        cloned_repo = git.Repo.clone_from(self.__create_clone_url(found_repo[1]), norm_path, branch='master')
         try:
             cloned_repo.remote()
             self.__update_daemon_csv(norm_path) 
         except:
             raise sys.stderr.write("Cloned repository does not have an origin remote. GitUp will not track automatically.\n")
         return cloned_repo
+    
+    def __create_clone_url(self, repo_url: str):
+        """
+        Arguments:
+           repo_url: the clone url of the repo to clone in the form https://remote_repo_url.git
+        
+        Takes in a repo_url of the above form. Returns a repo url in the form 
+        https://user_token@remote_repo_url.git to perform a authenticated clone of the remote repo.
+        """
+        # right half of remote
+        url = repo_url.split("https://")
+        # splice the url correctly
+        url = "https://{}@{}".format(self.curr_user.__token, url[1])
+        return url
     
     def __update_daemon_csv(self, path: str) -> bool:
         """

--- a/src/main/python/local_control/project_manager.py
+++ b/src/main/python/local_control/project_manager.py
@@ -105,7 +105,7 @@ class ProjectManager(object):
         
         # join norm path with repo_name for new directory
         norm_path = os.path.join(norm_path, repo_name)
-        cloned_repo = git.Repo.clone_from(self.__create_clone_url(found_repo[1]), norm_path, branch='master')
+        cloned_repo = git.Repo.clone_from(self.curr_user.create_clone_url(found_repo[1]), norm_path, branch='master')
         try:
             cloned_repo.remote()
             self.__update_daemon_csv(norm_path) 
@@ -113,19 +113,6 @@ class ProjectManager(object):
             raise sys.stderr.write("Cloned repository does not have an origin remote. GitUp will not track automatically.\n")
         return cloned_repo
     
-    def __create_clone_url(self, repo_url: str):
-        """
-        Arguments:
-           repo_url: the clone url of the repo to clone in the form https://remote_repo_url.git
-        
-        Takes in a repo_url of the above form. Returns a repo url in the form 
-        https://user_token@remote_repo_url.git to perform a authenticated clone of the remote repo.
-        """
-        # right half of remote
-        url = repo_url.split("https://")
-        # splice the url correctly
-        url = "https://{}@{}".format(self.curr_user.__token, url[1])
-        return url
     
     def __update_daemon_csv(self, path: str) -> bool:
         """


### PR DESCRIPTION
Fixes issues with cloning a repository that a user does not own (but may have access to) by sending a request to an authenticated clone url.