### PR TITLE
[HOT FIX] - push/pull following clone failing

### DIFF
--- a/src/main/python/local_control/project_manager.py
+++ b/src/main/python/local_control/project_manager.py
@@ -105,8 +105,12 @@ class ProjectManager(object):
         
         # join norm path with repo_name for new directory
         norm_path = os.path.join(norm_path, repo_name)
+        # perform an authenticated clone
         cloned_repo = git.Repo.clone_from(self.curr_user.create_clone_url(found_repo[1]), norm_path, branch='master')
         try:
+            # recreate the origin remote to avoid storing token
+            cloned_repo.delete_remote(cloned_repo.remote())
+            cloned_repo.create_remote(name="origin", url=found_repo[1]) 
             cloned_repo.remote()
             self.__update_daemon_csv(norm_path) 
         except:


### PR DESCRIPTION
Recreates origin remote after clone to remove the user's authentication token from the saved origin remote. Avoids security issue of storing the user's token in their repo remote urls.